### PR TITLE
Fixed read command in the envsetup.sh to be POSIX-compliant.

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -20,7 +20,8 @@ function choose_target() {
 	echo "Select Product:"
 	print_info "1. Duo (CV1800B)"
 	print_info "2. Duo256M (SG2002) or DuoS (SG2000)"
-	read -p "Which would you like: " chip_index
+	printf >&2 "%s" "Which would you like: "
+	read chip_index
 
 	if [ "${chip_index}" -eq 1 ]; then
 		milkv_chip="CV180X"
@@ -31,7 +32,8 @@ function choose_target() {
 		echo "Select Arch:"
 		print_info "1. ARM64"
 		print_info "2. RISCV64"
-		read -p "Which would you like: " arch_index
+		printf >&2 "%s" "Which would you like: "
+		read arch_index
 
 		if [ "${arch_index}" -eq 1 ]; then
 			milkv_arch="arm64"


### PR DESCRIPTION
The 'read -p' causes an error on the zsh.
Please, refer to 'https://unix.stackexchange.com/questions/198372/read-command-in-zsh-throws-error'.
